### PR TITLE
Fix leaking view by making mviView nullable

### DIFF
--- a/.plop-templates/mvi/{{pascalCase name}}Fragment.kt.hbs
+++ b/.plop-templates/mvi/{{pascalCase name}}Fragment.kt.hbs
@@ -14,17 +14,24 @@ class {{pascalCase name}}Fragment : BaseFragment<{{pascalCase name}}ViewState, {
 
     override val presenter by viewModels<{{pascalCase name}}Presenter>()
 
-    private lateinit var {{camelCase name}}View: {{pascalCase name}}MviView
+    private var {{camelCase name}}View: {{pascalCase name}}MviView? = null
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        {{camelCase name}}View = {{pascalCase name}}MviView(inflater, container, presenter::acceptIntent)
-        return {{camelCase name}}View.rootView
+        return {{pascalCase name}}MviView(inflater, container, presenter::acceptIntent).let {
+            {{camelCase name}}View = it
+            it.rootView
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        {{camelCase name}}View = null
     }
 
     override fun handleEvent(viewEvent: {{pascalCase name}}ViewEvent) {
     }
 
     override fun render(viewState: {{pascalCase name}}ViewState) {
-        {{camelCase name}}View.render(viewState)
+        {{camelCase name}}View?.render(viewState)
     }
 }

--- a/user/src/main/java/com/example/user/presentation/LoginFragment.kt
+++ b/user/src/main/java/com/example/user/presentation/LoginFragment.kt
@@ -15,11 +15,18 @@ class LoginFragment : BaseFragment<LoginViewState, LoginViewEvent, LoginPresente
 
     override val presenter by viewModels<LoginPresenter>()
 
-    private lateinit var loginView: LoginMviView
+    private var loginView: LoginMviView? = null
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        loginView = LoginMviView(inflater, container, presenter::acceptIntent)
-        return loginView.rootView
+        return LoginMviView(inflater, container, presenter::acceptIntent).let {
+            loginView = it
+            it.rootView
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        loginView = null
     }
 
     override fun handleEvent(viewEvent: LoginViewEvent) {
@@ -30,6 +37,6 @@ class LoginFragment : BaseFragment<LoginViewState, LoginViewEvent, LoginPresente
     }
 
     override fun render(viewState: LoginViewState) {
-        loginView.render(viewState)
+        loginView?.render(viewState)
     }
 }


### PR DESCRIPTION
This PR answers a nice question: _why should I clear Views references when using Fragments_ :)

Test scenario is simple:
- Navigate from `LoginFragment` to `HomeFragment` (by pressing Login/Logout) buttons several time
- Note that `LoginFragment` is kept on backstack

Result (without this PR):
```
2021-01-29 14:00:38.648 4458-4458/com.example D/LeakCanary: Watching instance of androidx.constraintlayout.widget.ConstraintLayout (com.example.user.presentation.LoginFragment received Fragment#onDestroyView() callback (references to its views should be cleared to prevent leaks)) with key 7850c776-dc59-41fe-b684-effbf20d737d
2021-01-29 14:00:43.765 4458-4498/com.example D/LeakCanary: Found 1 object retained, not dumping heap yet (app is visible & < 5 threshold)
```

with this PR:
```
2021-01-29 14:14:17.620 4689-4689/com.example D/LeakCanary: Watching instance of androidx.constraintlayout.widget.ConstraintLayout (com.example.user.presentation.LoginFragment received Fragment#onDestroyView() callback (references to its views should be cleared to prevent leaks)) with key deb779a9-f357-45d2-a669-8d5a98a81690
```

My understanding is that typically you don't see LeakCanary in this situation because of the leaks-detected threshold.

Solution is nice in that it (thanks to MVI and MviView) there is single point of null-check